### PR TITLE
Replace QuestPDF with PDFsharp for win-arm64 compatibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,3 @@
 <Project>
-  <!-- Intentionally empty - removed PlatformTarget to allow natural platform detection -->
-  <!-- QuestPDF library will work on supported platforms (x64/x86) and report clear errors on unsupported ones (ARM64) -->
+  <!-- PDFsharp Core library is used for PDF generation - it has no native dependencies and works on all platforms including win-arm64 -->
 </Project>

--- a/docs/reporting/README.md
+++ b/docs/reporting/README.md
@@ -9,7 +9,7 @@ The Phase 5 Reporting feature provides comprehensive report generation capabilit
 ### Report Formats
 
 - **HTML Reports**: Responsive, print-friendly web pages
-- **PDF Reports**: Professional PDF documents with QuestPDF
+- **PDF Reports**: Professional PDF documents with PDFsharp
 - **Excel Reports**: Multi-sheet workbooks with ClosedXML
 
 ### Report Content
@@ -36,7 +36,7 @@ car-search report -t <tenant-id> -f excel -o market-report.xlsx
 ## Dependencies
 
 - **Scriban** (5.10.0): HTML template engine
-- **QuestPDF** (2024.12.3): PDF generation
+- **PDFsharp** (6.2.0): PDF generation (cross-platform, win-arm64 compatible)
 - **ClosedXML** (0.104.2): Excel file generation
 
 ## Testing

--- a/docs/roadmaps/phase-5/README.md
+++ b/docs/roadmaps/phase-5/README.md
@@ -782,7 +782,7 @@ public class BatchDeduplicationService : IBatchDeduplicationService
 | S3-03 | Create HTML template | S3-02 | P0 |
 | S3-04 | Add search criteria section | S3-02 | P0 |
 | S3-05 | Add statistics section | S3-02 | P0 |
-| S3-06 | Add QuestPDF NuGet package | None | P1 |
+| S3-06 | Add PDFsharp NuGet package | None | P1 |
 | S3-07 | Implement PdfReportGenerator | S3-06 | P1 |
 | S3-08 | Add ClosedXML NuGet package | None | P2 |
 | S3-09 | Implement ExcelReportGenerator | S3-08 | P2 |

--- a/docs/roadmaps/phase-5/diagrams/report-generation.puml
+++ b/docs/roadmaps/phase-5/diagrams/report-generation.puml
@@ -44,7 +44,7 @@ case (HTML)
 
 case (PDF)
     :PdfReportGenerator;
-    :Create QuestPDF document;
+    :Create PDFsharp document;
     :Add header/footer;
     :Generate charts;
     :Render tables;

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/AutomatedMarketIntelligenceTool.Infrastructure.csproj
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/AutomatedMarketIntelligenceTool.Infrastructure.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.57.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
-    <PackageReference Include="QuestPDF" Version="2024.12.3" />
+    <PackageReference Include="PDFsharp" Version="6.2.0" />
     <PackageReference Include="Scriban" Version="5.10.0" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Reporting/PdfReportGenerator.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Reporting/PdfReportGenerator.cs
@@ -1,9 +1,8 @@
 using AutomatedMarketIntelligenceTool.Core.Models.ReportAggregate;
 using AutomatedMarketIntelligenceTool.Core.Services.Reporting;
 using Microsoft.Extensions.Logging;
-using QuestPDF.Fluent;
-using QuestPDF.Helpers;
-using QuestPDF.Infrastructure;
+using PdfSharp.Drawing;
+using PdfSharp.Pdf;
 
 namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Reporting;
 
@@ -11,195 +10,134 @@ public class PdfReportGenerator : IReportGenerator
 {
     private readonly ILogger<PdfReportGenerator> _logger;
 
+    // Colors
+    private static readonly XColor BlueMedium = XColor.FromArgb(33, 150, 243);
+    private static readonly XColor BlueDark = XColor.FromArgb(25, 118, 210);
+    private static readonly XColor GreenMedium = XColor.FromArgb(76, 175, 80);
+    private static readonly XColor GreyLight = XColor.FromArgb(245, 245, 245);
+    private static readonly XColor GreyDark = XColor.FromArgb(97, 97, 97);
+    private static readonly XColor GreyBorder = XColor.FromArgb(224, 224, 224);
+
+    // Page settings
+    private const double PageWidth = 595.0;  // A4 width in points
+    private const double PageHeight = 842.0; // A4 height in points
+    private const double Margin = 56.7;      // 2cm in points
+    private const double ContentWidth = PageWidth - (2 * Margin);
+
     public ReportFormat SupportedFormat => ReportFormat.Pdf;
 
     public PdfReportGenerator(ILogger<PdfReportGenerator> logger)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        
-        // Set QuestPDF license (Community license for open source projects)
-        QuestPDF.Settings.License = LicenseType.Community;
     }
 
     public Task<string> GenerateReportAsync(ReportData data, string outputPath, CancellationToken cancellationToken = default)
     {
         try
         {
-            Document.Create(container =>
+            using var document = new PdfDocument();
+            document.Info.Title = data.Title;
+            document.Info.Author = "Automated Market Intelligence Tool";
+
+            var page = document.AddPage();
+            page.Width = PageWidth;
+            page.Height = PageHeight;
+
+            var gfx = XGraphics.FromPdfPage(page);
+            var currentY = Margin;
+            var pageNumber = 1;
+            var totalListings = data.Listings?.Count ?? 0;
+
+            // Fonts
+            var titleFont = new XFont("Arial", 24, XFontStyleEx.Bold);
+            var subtitleFont = new XFont("Arial", 10, XFontStyleEx.Regular);
+            var sectionFont = new XFont("Arial", 16, XFontStyleEx.Bold);
+            var bodyFont = new XFont("Arial", 11, XFontStyleEx.Regular);
+            var smallFont = new XFont("Arial", 9, XFontStyleEx.Regular);
+            var tableHeaderFont = new XFont("Arial", 10, XFontStyleEx.Bold);
+            var tableBodyFont = new XFont("Arial", 9, XFontStyleEx.Regular);
+            var statValueFont = new XFont("Arial", 14, XFontStyleEx.Bold);
+            var courierFont = new XFont("Courier New", 9, XFontStyleEx.Regular);
+
+            // Draw Header
+            currentY = DrawHeader(gfx, data, currentY, titleFont, subtitleFont);
+
+            // Draw Search Criteria Section
+            if (!string.IsNullOrEmpty(data.SearchCriteria))
             {
-                container.Page(page =>
+                currentY = DrawSearchCriteria(gfx, data.SearchCriteria, currentY, sectionFont, courierFont);
+            }
+
+            // Draw Statistics Section
+            if (data.Statistics != null)
+            {
+                currentY = DrawStatistics(gfx, data.Statistics, currentY, sectionFont, smallFont, statValueFont);
+            }
+
+            // Draw Listings Section
+            currentY = DrawListingsHeader(gfx, totalListings, currentY, sectionFont);
+
+            if (data.Listings?.Any() == true)
+            {
+                // Draw table header
+                currentY = DrawTableHeader(gfx, currentY, tableHeaderFont);
+
+                // Draw listing rows
+                var listingsToShow = data.Listings.Take(100).ToList();
+                foreach (var listing in listingsToShow)
                 {
-                    page.Size(PageSizes.A4);
-                    page.Margin(2, Unit.Centimetre);
-                    page.PageColor(Colors.White);
-                    page.DefaultTextStyle(x => x.FontSize(11));
+                    // Check if we need a new page
+                    if (currentY + 25 > PageHeight - Margin - 30)
+                    {
+                        DrawFooter(gfx, pageNumber, -1); // -1 means we don't know total pages yet
+                        page = document.AddPage();
+                        page.Width = PageWidth;
+                        page.Height = PageHeight;
+                        gfx = XGraphics.FromPdfPage(page);
+                        pageNumber++;
+                        currentY = Margin;
+                        currentY = DrawTableHeader(gfx, currentY, tableHeaderFont);
+                    }
 
-                    page.Header()
-                        .BorderBottom(2)
-                        .BorderColor(Colors.Blue.Medium)
-                        .PaddingBottom(10)
-                        .Row(row =>
-                        {
-                            row.RelativeItem().Column(column =>
-                            {
-                                column.Item().Text(data.Title)
-                                    .FontSize(24)
-                                    .SemiBold()
-                                    .FontColor(Colors.Blue.Medium);
-                                
-                                column.Item().Text($"Generated: {data.GeneratedAt:yyyy-MM-dd HH:mm:ss UTC}")
-                                    .FontSize(10)
-                                    .FontColor(Colors.Grey.Darken2);
-                            });
-                        });
+                    currentY = DrawListingRow(gfx, listing, currentY, tableBodyFont);
+                }
 
-                    page.Content()
-                        .PaddingVertical(20)
-                        .Column(column =>
-                        {
-                            // Search Criteria Section
-                            if (!string.IsNullOrEmpty(data.SearchCriteria))
-                            {
-                                column.Item().PaddingBottom(15).Column(c =>
-                                {
-                                    c.Item().Text("Search Criteria")
-                                        .FontSize(16)
-                                        .SemiBold()
-                                        .FontColor(Colors.Blue.Medium);
-                                    
-                                    c.Item().PaddingTop(5).PaddingLeft(10)
-                                        .Background(Colors.Grey.Lighten3)
-                                        .Padding(10)
-                                        .Text(data.SearchCriteria)
-                                        .FontSize(9)
-                                        .FontFamily(Fonts.Courier);
-                                });
-                            }
+                // Note about truncated listings
+                if (totalListings > 100)
+                {
+                    currentY += 10;
+                    gfx.DrawString(
+                        $"Note: Showing first 100 of {totalListings} listings",
+                        new XFont("Arial", 9, XFontStyleEx.Italic),
+                        new XSolidBrush(GreyDark),
+                        new XRect(Margin, currentY, ContentWidth, 15),
+                        XStringFormats.TopLeft);
+                }
+            }
+            else
+            {
+                // No listings message
+                currentY += 20;
+                gfx.DrawString(
+                    "No listings to display",
+                    new XFont("Arial", 12, XFontStyleEx.Italic),
+                    new XSolidBrush(GreyDark),
+                    new XRect(Margin, currentY, ContentWidth, 20),
+                    XStringFormats.TopCenter);
+            }
 
-                            // Statistics Section
-                            if (data.Statistics != null)
-                            {
-                                column.Item().PaddingBottom(15).Column(c =>
-                                {
-                                    c.Item().Text("Market Statistics")
-                                        .FontSize(16)
-                                        .SemiBold()
-                                        .FontColor(Colors.Blue.Medium);
-                                    
-                                    c.Item().PaddingTop(10).Row(row =>
-                                    {
-                                        CreateStatCard(row, "Total Listings", data.Statistics.TotalListings.ToString("N0"));
-                                        
-                                        if (data.Statistics.AveragePrice.HasValue)
-                                            CreateStatCard(row, "Average Price", $"${data.Statistics.AveragePrice.Value:N2}");
-                                        
-                                        if (data.Statistics.MedianPrice.HasValue)
-                                            CreateStatCard(row, "Median Price", $"${data.Statistics.MedianPrice.Value:N2}");
-                                        
-                                        if (data.Statistics.AverageMileage.HasValue)
-                                            CreateStatCard(row, "Avg Mileage", $"{data.Statistics.AverageMileage.Value:N0} mi");
-                                    });
-                                });
-                            }
+            // Draw footer on last page and update all page footers
+            var totalPages = document.PageCount;
+            for (int i = 0; i < totalPages; i++)
+            {
+                var pageGfx = XGraphics.FromPdfPage(document.Pages[i]);
+                DrawFooter(pageGfx, i + 1, totalPages);
+            }
 
-                            // Listings Table
-                            column.Item().Column(c =>
-                            {
-                                c.Item().Text($"Listings ({data.Listings?.Count ?? 0})")
-                                    .FontSize(16)
-                                    .SemiBold()
-                                    .FontColor(Colors.Blue.Medium);
-                                
-                                if (data.Listings?.Any() == true)
-                                {
-                                    c.Item().PaddingTop(10).Table(table =>
-                                    {
-                                        // Define columns
-                                        table.ColumnsDefinition(columns =>
-                                        {
-                                            columns.ConstantColumn(40);  // Year
-                                            columns.RelativeColumn(1.5f); // Make
-                                            columns.RelativeColumn(2);    // Model
-                                            columns.RelativeColumn(1);    // Price
-                                            columns.RelativeColumn(1);    // Mileage
-                                            columns.RelativeColumn(1.5f); // Location
-                                            columns.RelativeColumn(1);    // Source
-                                        });
-
-                                        // Header
-                                        table.Header(header =>
-                                        {
-                                            header.Cell().Background(Colors.Blue.Medium)
-                                                .Padding(5).Text("Year").FontColor(Colors.White).SemiBold();
-                                            header.Cell().Background(Colors.Blue.Medium)
-                                                .Padding(5).Text("Make").FontColor(Colors.White).SemiBold();
-                                            header.Cell().Background(Colors.Blue.Medium)
-                                                .Padding(5).Text("Model").FontColor(Colors.White).SemiBold();
-                                            header.Cell().Background(Colors.Blue.Medium)
-                                                .Padding(5).Text("Price").FontColor(Colors.White).SemiBold();
-                                            header.Cell().Background(Colors.Blue.Medium)
-                                                .Padding(5).Text("Mileage").FontColor(Colors.White).SemiBold();
-                                            header.Cell().Background(Colors.Blue.Medium)
-                                                .Padding(5).Text("Location").FontColor(Colors.White).SemiBold();
-                                            header.Cell().Background(Colors.Blue.Medium)
-                                                .Padding(5).Text("Source").FontColor(Colors.White).SemiBold();
-                                        });
-
-                                        // Rows
-                                        foreach (var listing in data.Listings.Take(100)) // Limit to first 100 for PDF
-                                        {
-                                            table.Cell().BorderBottom(1).BorderColor(Colors.Grey.Lighten2)
-                                                .Padding(5).Text(listing.Year.ToString());
-                                            table.Cell().BorderBottom(1).BorderColor(Colors.Grey.Lighten2)
-                                                .Padding(5).Text(listing.Make ?? "N/A");
-                                            table.Cell().BorderBottom(1).BorderColor(Colors.Grey.Lighten2)
-                                                .Padding(5).Text(listing.Model ?? "N/A");
-                                            table.Cell().BorderBottom(1).BorderColor(Colors.Grey.Lighten2)
-                                                .Padding(5).Text($"${listing.Price:N2}").FontColor(Colors.Green.Medium).SemiBold();
-                                            table.Cell().BorderBottom(1).BorderColor(Colors.Grey.Lighten2)
-                                                .Padding(5).Text(listing.Mileage.HasValue ? $"{listing.Mileage.Value:N0}" : "N/A");
-                                            table.Cell().BorderBottom(1).BorderColor(Colors.Grey.Lighten2)
-                                                .Padding(5).Text(listing.Location ?? "N/A");
-                                            table.Cell().BorderBottom(1).BorderColor(Colors.Grey.Lighten2)
-                                                .Padding(5).Text(listing.SourceSite ?? "N/A");
-                                        }
-                                    });
-
-                                    if (data.Listings.Count > 100)
-                                    {
-                                        c.Item().PaddingTop(10)
-                                            .Text($"Note: Showing first 100 of {data.Listings.Count} listings")
-                                            .FontSize(9)
-                                            .Italic()
-                                            .FontColor(Colors.Grey.Darken1);
-                                    }
-                                }
-                                else
-                                {
-                                    c.Item().PaddingTop(20).AlignCenter()
-                                        .Text("No listings to display")
-                                        .FontSize(12)
-                                        .Italic()
-                                        .FontColor(Colors.Grey.Darken1);
-                                }
-                            });
-                        });
-
-                    page.Footer()
-                        .AlignCenter()
-                        .Text(x =>
-                        {
-                            x.Span("Page ");
-                            x.CurrentPageNumber();
-                            x.Span(" of ");
-                            x.TotalPages();
-                        });
-                });
-            })
-            .GeneratePdf(outputPath);
+            document.Save(outputPath);
 
             _logger.LogInformation("PDF report generated successfully at {Path}", outputPath);
-            
+
             return Task.FromResult(outputPath);
         }
         catch (Exception ex)
@@ -209,17 +147,248 @@ public class PdfReportGenerator : IReportGenerator
         }
     }
 
-    private void CreateStatCard(RowDescriptor row, string label, string value)
+    private double DrawHeader(XGraphics gfx, ReportData data, double y, XFont titleFont, XFont subtitleFont)
     {
-        row.RelativeItem().Padding(5).Background(Colors.Grey.Lighten3).Column(column =>
+        // Title
+        gfx.DrawString(
+            data.Title,
+            titleFont,
+            new XSolidBrush(BlueMedium),
+            new XRect(Margin, y, ContentWidth, 30),
+            XStringFormats.TopLeft);
+        y += 35;
+
+        // Generated date
+        gfx.DrawString(
+            $"Generated: {data.GeneratedAt:yyyy-MM-dd HH:mm:ss} UTC",
+            subtitleFont,
+            new XSolidBrush(GreyDark),
+            new XRect(Margin, y, ContentWidth, 15),
+            XStringFormats.TopLeft);
+        y += 20;
+
+        // Header border
+        gfx.DrawLine(new XPen(BlueMedium, 2), Margin, y, PageWidth - Margin, y);
+        y += 20;
+
+        return y;
+    }
+
+    private double DrawSearchCriteria(XGraphics gfx, string criteria, double y, XFont sectionFont, XFont courierFont)
+    {
+        // Section title
+        gfx.DrawString(
+            "Search Criteria",
+            sectionFont,
+            new XSolidBrush(BlueMedium),
+            new XRect(Margin, y, ContentWidth, 20),
+            XStringFormats.TopLeft);
+        y += 25;
+
+        // Criteria box background
+        var boxHeight = 40.0;
+        gfx.DrawRectangle(
+            new XSolidBrush(GreyLight),
+            Margin + 10, y, ContentWidth - 20, boxHeight);
+
+        // Criteria text
+        gfx.DrawString(
+            criteria,
+            courierFont,
+            XBrushes.Black,
+            new XRect(Margin + 20, y + 10, ContentWidth - 40, boxHeight - 20),
+            XStringFormats.TopLeft);
+
+        y += boxHeight + 15;
+        return y;
+    }
+
+    private double DrawStatistics(XGraphics gfx, MarketStatistics stats, double y, XFont sectionFont, XFont smallFont, XFont valueFont)
+    {
+        // Section title
+        gfx.DrawString(
+            "Market Statistics",
+            sectionFont,
+            new XSolidBrush(BlueMedium),
+            new XRect(Margin, y, ContentWidth, 20),
+            XStringFormats.TopLeft);
+        y += 30;
+
+        var statCards = new List<(string label, string value)>
         {
-            column.Item().Text(label)
-                .FontSize(9)
-                .FontColor(Colors.Grey.Darken2);
-            column.Item().PaddingTop(3).Text(value)
-                .FontSize(14)
-                .SemiBold()
-                .FontColor(Colors.Blue.Darken2);
-        });
+            ("Total Listings", stats.TotalListings.ToString("N0"))
+        };
+
+        if (stats.AveragePrice.HasValue)
+            statCards.Add(("Average Price", $"${stats.AveragePrice.Value:N2}"));
+        if (stats.MedianPrice.HasValue)
+            statCards.Add(("Median Price", $"${stats.MedianPrice.Value:N2}"));
+        if (stats.AverageMileage.HasValue)
+            statCards.Add(("Avg Mileage", $"{stats.AverageMileage.Value:N0} mi"));
+
+        var cardWidth = (ContentWidth - (statCards.Count - 1) * 10) / statCards.Count;
+        var cardHeight = 50.0;
+
+        for (int i = 0; i < statCards.Count; i++)
+        {
+            var x = Margin + i * (cardWidth + 10);
+
+            // Card background
+            gfx.DrawRectangle(new XSolidBrush(GreyLight), x, y, cardWidth, cardHeight);
+
+            // Label
+            gfx.DrawString(
+                statCards[i].label,
+                smallFont,
+                new XSolidBrush(GreyDark),
+                new XRect(x + 5, y + 8, cardWidth - 10, 15),
+                XStringFormats.TopLeft);
+
+            // Value
+            gfx.DrawString(
+                statCards[i].value,
+                valueFont,
+                new XSolidBrush(BlueDark),
+                new XRect(x + 5, y + 25, cardWidth - 10, 20),
+                XStringFormats.TopLeft);
+        }
+
+        y += cardHeight + 20;
+        return y;
+    }
+
+    private double DrawListingsHeader(XGraphics gfx, int totalListings, double y, XFont sectionFont)
+    {
+        gfx.DrawString(
+            $"Listings ({totalListings})",
+            sectionFont,
+            new XSolidBrush(BlueMedium),
+            new XRect(Margin, y, ContentWidth, 20),
+            XStringFormats.TopLeft);
+        y += 30;
+        return y;
+    }
+
+    private double DrawTableHeader(XGraphics gfx, double y, XFont font)
+    {
+        var columns = GetColumnWidths();
+        var headerHeight = 22.0;
+        var x = Margin;
+
+        string[] headers = { "Year", "Make", "Model", "Price", "Mileage", "Location", "Source" };
+
+        for (int i = 0; i < headers.Length; i++)
+        {
+            gfx.DrawRectangle(new XSolidBrush(BlueMedium), x, y, columns[i], headerHeight);
+            gfx.DrawString(
+                headers[i],
+                font,
+                XBrushes.White,
+                new XRect(x + 5, y + 4, columns[i] - 10, headerHeight - 8),
+                XStringFormats.TopLeft);
+            x += columns[i];
+        }
+
+        return y + headerHeight;
+    }
+
+    private double DrawListingRow(XGraphics gfx, Core.Models.ListingAggregate.Listing listing, double y, XFont font)
+    {
+        var columns = GetColumnWidths();
+        var rowHeight = 20.0;
+        var x = Margin;
+
+        string[] values =
+        {
+            listing.Year.ToString(),
+            listing.Make ?? "N/A",
+            listing.Model ?? "N/A",
+            $"${listing.Price:N2}",
+            listing.Mileage.HasValue ? $"{listing.Mileage.Value:N0}" : "N/A",
+            listing.Location ?? "N/A",
+            listing.SourceSite ?? "N/A"
+        };
+
+        XBrush[] brushes =
+        {
+            XBrushes.Black,
+            XBrushes.Black,
+            XBrushes.Black,
+            new XSolidBrush(GreenMedium),
+            XBrushes.Black,
+            XBrushes.Black,
+            XBrushes.Black
+        };
+
+        for (int i = 0; i < values.Length; i++)
+        {
+            // Cell border bottom
+            gfx.DrawLine(new XPen(GreyBorder, 1), x, y + rowHeight, x + columns[i], y + rowHeight);
+
+            // Truncate text if too long
+            var displayValue = TruncateText(values[i], font, columns[i] - 10, gfx);
+
+            gfx.DrawString(
+                displayValue,
+                font,
+                brushes[i],
+                new XRect(x + 5, y + 3, columns[i] - 10, rowHeight - 6),
+                XStringFormats.TopLeft);
+            x += columns[i];
+        }
+
+        return y + rowHeight;
+    }
+
+    private double[] GetColumnWidths()
+    {
+        // Proportional column widths that sum to ContentWidth
+        var totalParts = 40 + 75 + 100 + 60 + 60 + 85 + 62;
+        var scale = ContentWidth / totalParts;
+        return new[]
+        {
+            40 * scale,   // Year
+            75 * scale,   // Make
+            100 * scale,  // Model
+            60 * scale,   // Price
+            60 * scale,   // Mileage
+            85 * scale,   // Location
+            62 * scale    // Source
+        };
+    }
+
+    private string TruncateText(string text, XFont font, double maxWidth, XGraphics gfx)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+
+        var size = gfx.MeasureString(text, font);
+        if (size.Width <= maxWidth) return text;
+
+        // Truncate with ellipsis
+        for (int len = text.Length - 1; len > 0; len--)
+        {
+            var truncated = text.Substring(0, len) + "...";
+            size = gfx.MeasureString(truncated, font);
+            if (size.Width <= maxWidth) return truncated;
+        }
+
+        return "...";
+    }
+
+    private void DrawFooter(XGraphics gfx, int pageNumber, int totalPages)
+    {
+        var footerY = PageHeight - Margin + 10;
+        var footerFont = new XFont("Arial", 10, XFontStyleEx.Regular);
+
+        var footerText = totalPages > 0
+            ? $"Page {pageNumber} of {totalPages}"
+            : $"Page {pageNumber}";
+
+        gfx.DrawString(
+            footerText,
+            footerFont,
+            XBrushes.Black,
+            new XRect(Margin, footerY, ContentWidth, 15),
+            XStringFormats.TopCenter);
     }
 }


### PR DESCRIPTION
QuestPDF has native dependencies that don't support Windows ARM64. PDFsharp 6.2.0 is a pure .NET library with no native dependencies, making it compatible with all platforms including win-arm64.

Changes:
- Replace QuestPDF 2024.12.3 with PDFsharp 6.2.0 in Infrastructure.csproj
- Rewrite PdfReportGenerator.cs to use PDFsharp API
- Update Directory.Build.props with platform compatibility note
- Update documentation to reflect the library change