### PR TITLE
Create scrapers for car dealerships near Toronto

### DIFF
--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AtlasAutomotiveScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AtlasAutomotiveScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Atlas Automotive (atlasautomotive.ca) - Used car dealership in East Hamilton
+/// </summary>
+public class AtlasAutomotiveScraper : BaseScraper
+{
+    public override string SiteName => "AtlasAutomotive.ca";
+
+    public AtlasAutomotiveScraper(ILogger<AtlasAutomotiveScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.atlasautomotive.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.atlasautomotive.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Hamilton",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Atlas Automotive"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoConnectSalesScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoConnectSalesScraper.cs
@@ -1,0 +1,199 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Auto Connect Sales (autoconnectsales.ca) - Large assortment of high-quality vehicles in Peterborough
+/// </summary>
+public class AutoConnectSalesScraper : BaseScraper
+{
+    public override string SiteName => "AutoConnectSales.ca";
+
+    public AutoConnectSalesScraper(ILogger<AutoConnectSalesScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.autoconnectsales.ca/inventory.asp");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item, .listing", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item, .listing");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='vehicle.asp']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.autoconnectsales.ca{(href.StartsWith("/") ? "" : "/")}{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Peterborough",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Auto Connect Sales"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"[?&]id=(\d+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+
+            match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoDistrictScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoDistrictScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Auto District (autodistrict.ca) - Family-owned used car dealership in Mississauga
+/// </summary>
+public class AutoDistrictScraper : BaseScraper
+{
+    public override string SiteName => "AutoDistrict.ca";
+
+    public AutoDistrictScraper(ILogger<AutoDistrictScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.autodistrict.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-card", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-card");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.autodistrict.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Mississauga",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Auto District"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoParkBarrieScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoParkBarrieScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for AutoPark Barrie (autoparkbarrie.ca) - Part of Ontario's largest used car network
+/// </summary>
+public class AutoParkBarrieScraper : BaseScraper
+{
+    public override string SiteName => "AutoParkBarrie.ca";
+
+    public AutoParkBarrieScraper(ILogger<AutoParkBarrieScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.autoparkbarrie.ca/en/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_from={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_to={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_to={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-tile", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-tile");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.autoparkbarrie.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Barrie",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "AutoPark Barrie"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoParkBramptonScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoParkBramptonScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for AutoPark Brampton (autoparkbrampton.ca) - Part of Ontario's largest used car network
+/// </summary>
+public class AutoParkBramptonScraper : BaseScraper
+{
+    public override string SiteName => "AutoParkBrampton.ca";
+
+    public AutoParkBramptonScraper(ILogger<AutoParkBramptonScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.autoparkbrampton.ca/en/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_from={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_to={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_to={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-tile", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-tile");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.autoparkbrampton.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Brampton",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "AutoPark Brampton"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoPlanetDurhamScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoPlanetDurhamScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for AutoPlanet Durham (autoplanetdurham.ca) - Canada's largest indoor used car superstore with 800+ vehicles
+/// </summary>
+public class AutoPlanetDurhamScraper : BaseScraper
+{
+    public override string SiteName => "AutoPlanetDurham.ca";
+
+    public AutoPlanetDurhamScraper(ILogger<AutoPlanetDurhamScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.autoplanetdurham.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.autoplanetdurham.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Oshawa",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "AutoPlanet Durham"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoramaScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutoramaScraper.cs
@@ -1,0 +1,198 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Autorama (autorama.ca) - Major used car dealership in Toronto, North York & GTA
+/// </summary>
+public class AutoramaScraper : BaseScraper
+{
+    public override string SiteName => "Autorama.ca";
+
+    public AutoramaScraper(ILogger<AutoramaScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.autorama.ca/used-cars");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_from={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_to={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMin.HasValue)
+        {
+            queryParams.Append($"&price_from={decimal.ToInt32(parameters.PriceMin.Value)}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_to={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .car-title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/car/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.autorama.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Toronto",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Autorama"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|car|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutosourceScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/AutosourceScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for John Dewar's Autosource (autosource.ca) - Serving Peterborough since 1998
+/// </summary>
+public class AutosourceScraper : BaseScraper
+{
+    public override string SiteName => "Autosource.ca";
+
+    public AutosourceScraper(ILogger<AutosourceScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.autosource.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.autosource.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Peterborough",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "John Dewar's Autosource"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/BossAutoSalesScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/BossAutoSalesScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Boss Auto Sales (bossauto.ca) - Used car dealership in Oshawa since 2010
+/// </summary>
+public class BossAutoSalesScraper : BaseScraper
+{
+    public override string SiteName => "BossAuto.ca";
+
+    public BossAutoSalesScraper(ILogger<BossAutoSalesScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.bossauto.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.bossauto.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Oshawa",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Boss Auto Sales"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/CMHAutoSuperstoreScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/CMHAutoSuperstoreScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for CMH Auto Superstore (cmhniagara.com) - Over 200 vehicles in St. Catharines
+/// </summary>
+public class CMHAutoSuperstoreScraper : BaseScraper
+{
+    public override string SiteName => "CMHNiagara.com";
+
+    public CMHAutoSuperstoreScraper(ILogger<CMHAutoSuperstoreScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://cmhniagara.com/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://cmhniagara.com{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "St. Catharines",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "CMH Auto Superstore"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/CarCentralScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/CarCentralScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Car Central (carcentral.ca) - Top-rated pre-owned dealership in Barrie
+/// </summary>
+public class CarCentralScraper : BaseScraper
+{
+    public override string SiteName => "CarCentral.ca";
+
+    public CarCentralScraper(ILogger<CarCentralScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.carcentral.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.carcentral.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Barrie",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Car Central"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/CarConnectionTorontoScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/CarConnectionTorontoScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Car Connection Toronto (carconnectiontoronto.ca) - Pre-owned dealership in North York
+/// </summary>
+public class CarConnectionTorontoScraper : BaseScraper
+{
+    public override string SiteName => "CarConnectionToronto.ca";
+
+    public CarConnectionTorontoScraper(ILogger<CarConnectionTorontoScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.carconnectiontoronto.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-listing", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-listing");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4, .car-name");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/'], a[href*='/car/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.carconnectiontoronto.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Toronto",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Car Connection Toronto"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory|car)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/CarNationCanadaScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/CarNationCanadaScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Car Nation Canada Direct (carnationcanadadirect.ca) - Pre-owned superstore in Burlington with 100+ vehicles
+/// </summary>
+public class CarNationCanadaScraper : BaseScraper
+{
+    public override string SiteName => "CarNationCanadaDirect.ca";
+
+    public CarNationCanadaScraper(ILogger<CarNationCanadaScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.carnationcanadadirect.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.carnationcanadadirect.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Burlington",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Car Nation Canada Direct"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/CedarAutoScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/CedarAutoScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Cedar Auto (cedarauto.ca) - Used car dealership in London, Ontario
+/// </summary>
+public class CedarAutoScraper : BaseScraper
+{
+    public override string SiteName => "CedarAuto.ca";
+
+    public CedarAutoScraper(ILogger<CedarAutoScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.cedarauto.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.cedarauto.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "London",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Cedar Auto"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/DannyAndSonsScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/DannyAndSonsScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Danny & Sons Auto Sales (dannyandsons.com) - Used car dealership in Mississauga
+/// </summary>
+public class DannyAndSonsScraper : BaseScraper
+{
+    public override string SiteName => "DannyAndSons.com";
+
+    public DannyAndSonsScraper(ILogger<DannyAndSonsScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://dannyandsons.com/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://dannyandsons.com{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Mississauga",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Danny & Sons Auto Sales"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/DriftMotorsScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/DriftMotorsScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for DRIFT Motors (driftmotors.ca) - Used car dealership in Brampton
+/// </summary>
+public class DriftMotorsScraper : BaseScraper
+{
+    public override string SiteName => "DriftMotors.ca";
+
+    public DriftMotorsScraper(ILogger<DriftMotorsScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.driftmotors.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.driftmotors.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Brampton",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "DRIFT Motors"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/EmpireAutoGroupScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/EmpireAutoGroupScraper.cs
@@ -1,0 +1,199 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Empire Auto Group (empireautogroup.ca) - Major used car dealer in London, Ontario
+/// </summary>
+public class EmpireAutoGroupScraper : BaseScraper
+{
+    public override string SiteName => "EmpireAutoGroup.ca";
+
+    public EmpireAutoGroupScraper(ILogger<EmpireAutoGroupScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://empireautogroup.ca/inventory.php");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item, .vehicle-listing", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item, .vehicle-listing");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4, .car-name");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='vehicle.php'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://empireautogroup.ca{(href.StartsWith("/") ? "" : "/")}{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "London",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Empire Auto Group"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"[?&]id=(\d+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+
+            match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/FineMotorsLondonScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/FineMotorsLondonScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Fine Motors of London (finemotors.ca) - Used car dealership in London, Ontario
+/// </summary>
+public class FineMotorsLondonScraper : BaseScraper
+{
+    public override string SiteName => "FineMotors.ca";
+
+    public FineMotorsLondonScraper(ILogger<FineMotorsLondonScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.finemotors.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.finemotors.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "London",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Fine Motors of London"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/FirstMotorsScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/FirstMotorsScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for First Motors (firstmotors.ca) - Used car dealership in Brampton
+/// </summary>
+public class FirstMotorsScraper : BaseScraper
+{
+    public override string SiteName => "FirstMotors.ca";
+
+    public FirstMotorsScraper(ILogger<FirstMotorsScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.firstmotors.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.firstmotors.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Brampton",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "First Motors"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/FitzgeraldMotorsScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/FitzgeraldMotorsScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Fitzgerald Motors (fitzgeraldmotors.com) - Used vehicle dealer in Kitchener with 25+ years experience
+/// </summary>
+public class FitzgeraldMotorsScraper : BaseScraper
+{
+    public override string SiteName => "FitzgeraldMotors.com";
+
+    public FitzgeraldMotorsScraper(ILogger<FitzgeraldMotorsScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.fitzgeraldmotors.com/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.fitzgeraldmotors.com{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Kitchener",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Fitzgerald Motors"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/GDCoatesSuperstoreScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/GDCoatesSuperstoreScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for G.D. Coates Superstore (gdcoatessuperstore.ca) - The Original Used Car Superstore in Barrie since 1973
+/// </summary>
+public class GDCoatesSuperstoreScraper : BaseScraper
+{
+    public override string SiteName => "GDCoatesSuperstore.ca";
+
+    public GDCoatesSuperstoreScraper(ILogger<GDCoatesSuperstoreScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.gdcoatessuperstore.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.gdcoatessuperstore.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Barrie",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "G.D. Coates Superstore"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/GlobalAutomartScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/GlobalAutomartScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Global Automart Inc (globalautomart.ca) - Used car dealership in Hamilton
+/// </summary>
+public class GlobalAutomartScraper : BaseScraper
+{
+    public override string SiteName => "GlobalAutomart.ca";
+
+    public GlobalAutomartScraper(ILogger<GlobalAutomartScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.globalautomart.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.globalautomart.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Hamilton",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Global Automart Inc"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/KnightsAutoSalesScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/KnightsAutoSalesScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Knight's Auto Sales (knightsautosales.com) - Used car dealership in Oakville
+/// </summary>
+public class KnightsAutoSalesScraper : BaseScraper
+{
+    public override string SiteName => "KnightsAutoSales.com";
+
+    public KnightsAutoSalesScraper(ILogger<KnightsAutoSalesScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.knightsautosales.com/cars");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/cars/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.knightsautosales.com{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Oakville",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Knight's Auto Sales"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|cars)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/LebadaMotorsScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/LebadaMotorsScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Lebada Motors Superstore (lebadamotors.com) - 200+ certified vehicles in Cambridge since 1999
+/// </summary>
+public class LebadaMotorsScraper : BaseScraper
+{
+    public override string SiteName => "LebadaMotors.com";
+
+    public LebadaMotorsScraper(ILogger<LebadaMotorsScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.lebadamotors.com/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.lebadamotors.com{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Cambridge",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Lebada Motors Superstore"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/MarkWilsonsScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/MarkWilsonsScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Mark Wilson's Better Used Cars (shopwilsons.com) - Local used car superstore in Guelph with 534+ vehicles
+/// </summary>
+public class MarkWilsonsScraper : BaseScraper
+{
+    public override string SiteName => "ShopWilsons.com";
+
+    public MarkWilsonsScraper(ILogger<MarkWilsonsScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.shopwilsons.com/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.shopwilsons.com{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Guelph",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Mark Wilson's Better Used Cars"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/MilburnsAutoSalesScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/MilburnsAutoSalesScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Milburn's Auto Sales (milburnsautosales.com) - Guelph's largest south end used car dealer since 1969
+/// </summary>
+public class MilburnsAutoSalesScraper : BaseScraper
+{
+    public override string SiteName => "MilburnsAutoSales.com";
+
+    public MilburnsAutoSalesScraper(ILogger<MilburnsAutoSalesScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.milburnsautosales.com/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.milburnsautosales.com{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Guelph",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Milburn's Auto Sales"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/MississaugaAutoGroupScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/MississaugaAutoGroupScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Mississauga Auto Group (mississaugaautogroup.com) - Used car dealership in Mississauga
+/// </summary>
+public class MississaugaAutoGroupScraper : BaseScraper
+{
+    public override string SiteName => "MississaugaAutoGroup.com";
+
+    public MississaugaAutoGroupScraper(ILogger<MississaugaAutoGroupScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://mississaugaautogroup.com/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://mississaugaautogroup.com{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Mississauga",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Mississauga Auto Group"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/MostWantedCarsScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/MostWantedCarsScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Most Wanted Cars (mostwantedcars.ca) - #1 Rated Pre-Owned Dealer in Kitchener/Waterloo
+/// </summary>
+public class MostWantedCarsScraper : BaseScraper
+{
+    public override string SiteName => "MostWantedCars.ca";
+
+    public MostWantedCarsScraper(ILogger<MostWantedCarsScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.mostwantedcars.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item, .listing", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item, .listing");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.mostwantedcars.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Kitchener",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Most Wanted Cars"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/NexcarScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/NexcarScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Nexcar Auto Sales & Leasing (nexcar.ca) - Used car dealership in Toronto, North York & GTA
+/// </summary>
+public class NexcarScraper : BaseScraper
+{
+    public override string SiteName => "Nexcar.ca";
+
+    public NexcarScraper(ILogger<NexcarScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.nexcar.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .listing-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .listing-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price, .listing-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.nexcar.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Toronto",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Nexcar Auto Sales & Leasing"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next'], .next-page");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/OntarioAutoOutletScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/OntarioAutoOutletScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Ontario Auto Outlet (oaocars.com) - 100% CarFax reports in Cambridge
+/// </summary>
+public class OntarioAutoOutletScraper : BaseScraper
+{
+    public override string SiteName => "OAOCars.com";
+
+    public OntarioAutoOutletScraper(ILogger<OntarioAutoOutletScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.oaocars.com/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.oaocars.com{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Cambridge",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Ontario Auto Outlet"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/PfaffAutomotiveScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/PfaffAutomotiveScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Pfaff Automotive Partners (pfaffauto.com) - Premium used cars in Markham, Vaughan, Richmond Hill
+/// </summary>
+public class PfaffAutomotiveScraper : BaseScraper
+{
+    public override string SiteName => "PfaffAuto.com";
+
+    public PfaffAutomotiveScraper(ILogger<PfaffAutomotiveScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.pfaffauto.com/used-vehicles");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/used-vehicles/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.pfaffauto.com{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Markham",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Pfaff Automotive Partners"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|used-vehicles)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/QualityCarSalesScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/QualityCarSalesScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Quality Car Sales (qualitycarsales.com) - Family-run dealership in Kitchener/Waterloo with 40+ years
+/// </summary>
+public class QualityCarSalesScraper : BaseScraper
+{
+    public override string SiteName => "QualityCarSales.com";
+
+    public QualityCarSalesScraper(ILogger<QualityCarSalesScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.qualitycarsales.com/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.qualitycarsales.com{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Kitchener",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Quality Car Sales"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/ScraperFactory.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/ScraperFactory.cs
@@ -29,6 +29,7 @@ public class ScraperFactory : IScraperFactory
         
         ISiteScraper scraper = siteName.ToLowerInvariant() switch
         {
+            // Major aggregator sites
             "autotrader" or "autotrader.ca" => new AutotraderScraper(_loggerFactory.CreateLogger<AutotraderScraper>()),
             "kijiji" or "kijiji.ca" => new KijijiScraper(_loggerFactory.CreateLogger<KijijiScraper>()),
             "cargurus" or "cargurus.ca" => new CarGurusScraper(_loggerFactory.CreateLogger<CarGurusScraper>()),
@@ -39,7 +40,72 @@ public class ScraperFactory : IScraperFactory
             "vroom" or "vroom.com" => new VroomScraper(_loggerFactory.CreateLogger<VroomScraper>()),
             "truecar" or "truecar.com" => new TrueCarScraper(_loggerFactory.CreateLogger<TrueCarScraper>()),
             "carfax" or "carfax.ca" => new CarFaxScraper(_loggerFactory.CreateLogger<CarFaxScraper>()),
+
+            // Toronto dealerships
+            "autorama" or "autorama.ca" => new AutoramaScraper(_loggerFactory.CreateLogger<AutoramaScraper>()),
+            "nexcar" or "nexcar.ca" => new NexcarScraper(_loggerFactory.CreateLogger<NexcarScraper>()),
+            "carconnectiontoronto" or "carconnectiontoronto.ca" => new CarConnectionTorontoScraper(_loggerFactory.CreateLogger<CarConnectionTorontoScraper>()),
+
+            // Mississauga dealerships
             "tabangimotors" or "tabangimotors.com" => new TabangiMotorsScraper(_loggerFactory.CreateLogger<TabangiMotorsScraper>()),
+            "autodistrict" or "autodistrict.ca" => new AutoDistrictScraper(_loggerFactory.CreateLogger<AutoDistrictScraper>()),
+            "dannyandsons" or "dannyandsons.com" => new DannyAndSonsScraper(_loggerFactory.CreateLogger<DannyAndSonsScraper>()),
+            "mississaugaautogroup" or "mississaugaautogroup.com" => new MississaugaAutoGroupScraper(_loggerFactory.CreateLogger<MississaugaAutoGroupScraper>()),
+
+            // Brampton dealerships
+            "autoparkbrampton" or "autoparkbrampton.ca" => new AutoParkBramptonScraper(_loggerFactory.CreateLogger<AutoParkBramptonScraper>()),
+            "firstmotors" or "firstmotors.ca" => new FirstMotorsScraper(_loggerFactory.CreateLogger<FirstMotorsScraper>()),
+            "driftmotors" or "driftmotors.ca" => new DriftMotorsScraper(_loggerFactory.CreateLogger<DriftMotorsScraper>()),
+
+            // Hamilton dealerships
+            "globalautomart" or "globalautomart.ca" => new GlobalAutomartScraper(_loggerFactory.CreateLogger<GlobalAutomartScraper>()),
+            "waynesautoworld" or "waynesautoworld.ca" => new WaynesAutoWorldScraper(_loggerFactory.CreateLogger<WaynesAutoWorldScraper>()),
+            "atlasautomotive" or "atlasautomotive.ca" => new AtlasAutomotiveScraper(_loggerFactory.CreateLogger<AtlasAutomotiveScraper>()),
+
+            // Kitchener-Waterloo dealerships
+            "mostwantedcars" or "mostwantedcars.ca" => new MostWantedCarsScraper(_loggerFactory.CreateLogger<MostWantedCarsScraper>()),
+            "qualitycarsales" or "qualitycarsales.com" => new QualityCarSalesScraper(_loggerFactory.CreateLogger<QualityCarSalesScraper>()),
+            "fitzgeraldmotors" or "fitzgeraldmotors.com" => new FitzgeraldMotorsScraper(_loggerFactory.CreateLogger<FitzgeraldMotorsScraper>()),
+
+            // London dealerships
+            "empireatogroup" or "empireautogroup.ca" => new EmpireAutoGroupScraper(_loggerFactory.CreateLogger<EmpireAutoGroupScraper>()),
+            "finemotors" or "finemotors.ca" => new FineMotorsLondonScraper(_loggerFactory.CreateLogger<FineMotorsLondonScraper>()),
+            "cedarauto" or "cedarauto.ca" => new CedarAutoScraper(_loggerFactory.CreateLogger<CedarAutoScraper>()),
+
+            // Barrie dealerships
+            "carcentral" or "carcentral.ca" => new CarCentralScraper(_loggerFactory.CreateLogger<CarCentralScraper>()),
+            "gdcoatessuperstore" or "gdcoatessuperstore.ca" => new GDCoatesSuperstoreScraper(_loggerFactory.CreateLogger<GDCoatesSuperstoreScraper>()),
+            "autoparkbarrie" or "autoparkbarrie.ca" => new AutoParkBarrieScraper(_loggerFactory.CreateLogger<AutoParkBarrieScraper>()),
+
+            // Oshawa/Durham dealerships
+            "autoplanetdurham" or "autoplanetdurham.ca" => new AutoPlanetDurhamScraper(_loggerFactory.CreateLogger<AutoPlanetDurhamScraper>()),
+            "bossauto" or "bossauto.ca" => new BossAutoSalesScraper(_loggerFactory.CreateLogger<BossAutoSalesScraper>()),
+            "truenorthautomobiles" or "truenorthautomobiles.ca" => new TrueNorthAutomobilesScraper(_loggerFactory.CreateLogger<TrueNorthAutomobilesScraper>()),
+
+            // St. Catharines/Niagara dealerships
+            "cmhniagara" or "cmhniagara.com" => new CMHAutoSuperstoreScraper(_loggerFactory.CreateLogger<CMHAutoSuperstoreScraper>()),
+            "skywayfinecars" or "skywayfinecars.ca" => new SkywayFineCarsScraper(_loggerFactory.CreateLogger<SkywayFineCarsScraper>()),
+            "twoguys" or "twoguys.ca" => new TwoGuysQualityCarsScraper(_loggerFactory.CreateLogger<TwoGuysQualityCarsScraper>()),
+
+            // Guelph dealerships
+            "shopwilsons" or "shopwilsons.com" => new MarkWilsonsScraper(_loggerFactory.CreateLogger<MarkWilsonsScraper>()),
+            "milburnsautosales" or "milburnsautosales.com" => new MilburnsAutoSalesScraper(_loggerFactory.CreateLogger<MilburnsAutoSalesScraper>()),
+
+            // Cambridge dealerships
+            "lebadamotors" or "lebadamotors.com" => new LebadaMotorsScraper(_loggerFactory.CreateLogger<LebadaMotorsScraper>()),
+            "oaocars" or "oaocars.com" => new OntarioAutoOutletScraper(_loggerFactory.CreateLogger<OntarioAutoOutletScraper>()),
+
+            // Peterborough dealerships
+            "autoconnectsales" or "autoconnectsales.ca" => new AutoConnectSalesScraper(_loggerFactory.CreateLogger<AutoConnectSalesScraper>()),
+            "autosource" or "autosource.ca" => new AutosourceScraper(_loggerFactory.CreateLogger<AutosourceScraper>()),
+
+            // Burlington/Oakville dealerships
+            "carnationcanadadirect" or "carnationcanadadirect.ca" => new CarNationCanadaScraper(_loggerFactory.CreateLogger<CarNationCanadaScraper>()),
+            "knightsautosales" or "knightsautosales.com" => new KnightsAutoSalesScraper(_loggerFactory.CreateLogger<KnightsAutoSalesScraper>()),
+
+            // Richmond Hill/Markham/Vaughan dealerships
+            "pfaffauto" or "pfaffauto.com" => new PfaffAutomotiveScraper(_loggerFactory.CreateLogger<PfaffAutomotiveScraper>()),
+
             _ => throw new ArgumentException($"Unsupported site: {siteName}", nameof(siteName))
         };
 
@@ -60,7 +126,8 @@ public class ScraperFactory : IScraperFactory
     public IEnumerable<ISiteScraper> CreateAllScrapers()
     {
         _logger.LogInformation("Creating all supported scrapers");
-        
+
+        // Major aggregator sites
         yield return CreateScraper("autotrader");
         yield return CreateScraper("kijiji");
         yield return CreateScraper("cargurus");
@@ -71,15 +138,80 @@ public class ScraperFactory : IScraperFactory
         yield return CreateScraper("vroom");
         yield return CreateScraper("truecar");
         yield return CreateScraper("carfax");
+
+        // Toronto dealerships
+        yield return CreateScraper("autorama");
+        yield return CreateScraper("nexcar");
+        yield return CreateScraper("carconnectiontoronto");
+
+        // Mississauga dealerships
         yield return CreateScraper("tabangimotors");
+        yield return CreateScraper("autodistrict");
+        yield return CreateScraper("dannyandsons");
+        yield return CreateScraper("mississaugaautogroup");
+
+        // Brampton dealerships
+        yield return CreateScraper("autoparkbrampton");
+        yield return CreateScraper("firstmotors");
+        yield return CreateScraper("driftmotors");
+
+        // Hamilton dealerships
+        yield return CreateScraper("globalautomart");
+        yield return CreateScraper("waynesautoworld");
+        yield return CreateScraper("atlasautomotive");
+
+        // Kitchener-Waterloo dealerships
+        yield return CreateScraper("mostwantedcars");
+        yield return CreateScraper("qualitycarsales");
+        yield return CreateScraper("fitzgeraldmotors");
+
+        // London dealerships
+        yield return CreateScraper("empireatogroup");
+        yield return CreateScraper("finemotors");
+        yield return CreateScraper("cedarauto");
+
+        // Barrie dealerships
+        yield return CreateScraper("carcentral");
+        yield return CreateScraper("gdcoatessuperstore");
+        yield return CreateScraper("autoparkbarrie");
+
+        // Oshawa/Durham dealerships
+        yield return CreateScraper("autoplanetdurham");
+        yield return CreateScraper("bossauto");
+        yield return CreateScraper("truenorthautomobiles");
+
+        // St. Catharines/Niagara dealerships
+        yield return CreateScraper("cmhniagara");
+        yield return CreateScraper("skywayfinecars");
+        yield return CreateScraper("twoguys");
+
+        // Guelph dealerships
+        yield return CreateScraper("shopwilsons");
+        yield return CreateScraper("milburnsautosales");
+
+        // Cambridge dealerships
+        yield return CreateScraper("lebadamotors");
+        yield return CreateScraper("oaocars");
+
+        // Peterborough dealerships
+        yield return CreateScraper("autoconnectsales");
+        yield return CreateScraper("autosource");
+
+        // Burlington/Oakville dealerships
+        yield return CreateScraper("carnationcanadadirect");
+        yield return CreateScraper("knightsautosales");
+
+        // Richmond Hill/Markham/Vaughan dealerships
+        yield return CreateScraper("pfaffauto");
     }
 
     public IEnumerable<string> GetSupportedSites()
     {
-        return new[] 
-        { 
-            "Autotrader.ca", 
-            "Kijiji.ca", 
+        return new[]
+        {
+            // Major aggregator sites
+            "Autotrader.ca",
+            "Kijiji.ca",
             "CarGurus.ca",
             "Clutch.ca",
             "Auto123.com",
@@ -88,7 +220,57 @@ public class ScraperFactory : IScraperFactory
             "Vroom.com",
             "TrueCar.com",
             "CarFax.ca",
-            "TabangiMotors.com"
+            // Toronto dealerships
+            "Autorama.ca",
+            "Nexcar.ca",
+            "CarConnectionToronto.ca",
+            // Mississauga dealerships
+            "TabangiMotors.com",
+            "AutoDistrict.ca",
+            "DannyAndSons.com",
+            "MississaugaAutoGroup.com",
+            // Brampton dealerships
+            "AutoParkBrampton.ca",
+            "FirstMotors.ca",
+            "DriftMotors.ca",
+            // Hamilton dealerships
+            "GlobalAutomart.ca",
+            "WaynesAutoWorld.ca",
+            "AtlasAutomotive.ca",
+            // Kitchener-Waterloo dealerships
+            "MostWantedCars.ca",
+            "QualityCarSales.com",
+            "FitzgeraldMotors.com",
+            // London dealerships
+            "EmpireAutoGroup.ca",
+            "FineMotors.ca",
+            "CedarAuto.ca",
+            // Barrie dealerships
+            "CarCentral.ca",
+            "GDCoatesSuperstore.ca",
+            "AutoParkBarrie.ca",
+            // Oshawa/Durham dealerships
+            "AutoPlanetDurham.ca",
+            "BossAuto.ca",
+            "TrueNorthAutomobiles.ca",
+            // St. Catharines/Niagara dealerships
+            "CMHNiagara.com",
+            "SkywayFineCars.ca",
+            "TwoGuys.ca",
+            // Guelph dealerships
+            "ShopWilsons.com",
+            "MilburnsAutoSales.com",
+            // Cambridge dealerships
+            "LebadaMotors.com",
+            "OAOCars.com",
+            // Peterborough dealerships
+            "AutoConnectSales.ca",
+            "Autosource.ca",
+            // Burlington/Oakville dealerships
+            "CarNationCanadaDirect.ca",
+            "KnightsAutoSales.com",
+            // Richmond Hill/Markham/Vaughan dealerships
+            "PfaffAuto.com"
         };
     }
 }

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/SkywayFineCarsScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/SkywayFineCarsScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Skyway Fine Cars (skywayfinecars.ca) - Serving St. Catharines and Niagara for 37+ years
+/// </summary>
+public class SkywayFineCarsScraper : BaseScraper
+{
+    public override string SiteName => "SkywayFineCars.ca";
+
+    public SkywayFineCarsScraper(ILogger<SkywayFineCarsScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.skywayfinecars.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.skywayfinecars.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "St. Catharines",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Skyway Fine Cars"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/TrueNorthAutomobilesScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/TrueNorthAutomobilesScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for True North Automobiles (truenorthautomobiles.ca) - Used car dealership in Oshawa
+/// </summary>
+public class TrueNorthAutomobilesScraper : BaseScraper
+{
+    public override string SiteName => "TrueNorthAutomobiles.ca";
+
+    public TrueNorthAutomobilesScraper(ILogger<TrueNorthAutomobilesScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.truenorthautomobiles.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.truenorthautomobiles.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Oshawa",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "True North Automobiles"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/TwoGuysQualityCarsScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/TwoGuysQualityCarsScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Two Guys Quality Cars (twoguys.ca) - Serving St. Catharines for over 30 years
+/// </summary>
+public class TwoGuysQualityCarsScraper : BaseScraper
+{
+    public override string SiteName => "TwoGuys.ca";
+
+    public TwoGuysQualityCarsScraper(ILogger<TwoGuysQualityCarsScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.twoguys.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.twoguys.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "St. Catharines",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Two Guys Quality Cars"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}

--- a/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/WaynesAutoWorldScraper.cs
+++ b/src/AutomatedMarketIntelligenceTool.Infrastructure/Services/Scrapers/WaynesAutoWorldScraper.cs
@@ -1,0 +1,193 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using AutomatedMarketIntelligenceTool.Core.Models.ListingAggregate.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Playwright;
+
+namespace AutomatedMarketIntelligenceTool.Infrastructure.Services.Scrapers;
+
+/// <summary>
+/// Scraper for Wayne's Auto World (waynesautoworld.ca) - Used car dealership in Hamilton since 1998
+/// </summary>
+public class WaynesAutoWorldScraper : BaseScraper
+{
+    public override string SiteName => "WaynesAutoWorld.ca";
+
+    public WaynesAutoWorldScraper(ILogger<WaynesAutoWorldScraper> logger)
+        : base(logger)
+    {
+    }
+
+    protected override string BuildSearchUrl(SearchParameters parameters, int page)
+    {
+        var baseUrl = new StringBuilder("https://www.waynesautoworld.ca/inventory");
+        var queryParams = new StringBuilder();
+
+        queryParams.Append($"?page={page}");
+
+        if (!string.IsNullOrWhiteSpace(parameters.Make))
+        {
+            queryParams.Append($"&make={HttpUtility.UrlEncode(parameters.Make)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(parameters.Model))
+        {
+            queryParams.Append($"&model={HttpUtility.UrlEncode(parameters.Model)}");
+        }
+
+        if (parameters.YearMin.HasValue)
+        {
+            queryParams.Append($"&year_min={parameters.YearMin.Value}");
+        }
+
+        if (parameters.YearMax.HasValue)
+        {
+            queryParams.Append($"&year_max={parameters.YearMax.Value}");
+        }
+
+        if (parameters.PriceMax.HasValue)
+        {
+            queryParams.Append($"&price_max={decimal.ToInt32(parameters.PriceMax.Value)}");
+        }
+
+        return baseUrl.ToString() + queryParams.ToString();
+    }
+
+    protected override async Task<IEnumerable<ScrapedListing>> ParseListingsAsync(
+        IPage page,
+        CancellationToken cancellationToken)
+    {
+        var listings = new List<ScrapedListing>();
+
+        try
+        {
+            await page.WaitForSelectorAsync(".vehicle-card, .inventory-item, .car-item", new PageWaitForSelectorOptions
+            {
+                Timeout = 10000
+            });
+
+            var listingElements = await page.QuerySelectorAllAsync(".vehicle-card, .inventory-item, .car-item");
+
+            _logger.LogDebug("Found {Count} listing elements on page", listingElements.Count);
+
+            foreach (var element in listingElements)
+            {
+                try
+                {
+                    var listing = await ParseListingElementAsync(element, cancellationToken);
+                    if (listing != null)
+                    {
+                        listings.Add(listing);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse individual listing element");
+                }
+            }
+        }
+        catch (TimeoutException)
+        {
+            _logger.LogWarning("Timeout waiting for listing elements, page may be empty");
+        }
+
+        return listings;
+    }
+
+    private async Task<ScrapedListing?> ParseListingElementAsync(
+        IElementHandle element,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var titleElement = await element.QuerySelectorAsync(".vehicle-title, .title, h3, h4");
+            var title = titleElement != null ? await titleElement.InnerTextAsync() : string.Empty;
+
+            var priceElement = await element.QuerySelectorAsync(".price, .vehicle-price");
+            var priceText = priceElement != null ? await priceElement.InnerTextAsync() : "0";
+            var price = ParsePrice(priceText);
+
+            var linkElement = await element.QuerySelectorAsync("a[href*='/vehicle/'], a[href*='/inventory/']");
+            var href = linkElement != null ? await linkElement.GetAttributeAsync("href") ?? string.Empty : string.Empty;
+            var listingUrl = href.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                ? href
+                : $"https://www.waynesautoworld.ca{href}";
+
+            var externalId = ExtractExternalId(listingUrl);
+
+            var mileageElement = await element.QuerySelectorAsync(".mileage, .odometer, .km");
+            var mileageText = mileageElement != null ? await mileageElement.InnerTextAsync() : string.Empty;
+            var mileage = ParseMileage(mileageText);
+
+            var (make, model, year) = ParseTitle(title);
+
+            if (string.IsNullOrEmpty(make) || string.IsNullOrEmpty(model) || year == 0)
+            {
+                _logger.LogWarning("Failed to parse required fields from title: {Title}", title);
+                return null;
+            }
+
+            return new ScrapedListing
+            {
+                ExternalId = externalId,
+                SourceSite = SiteName,
+                ListingUrl = listingUrl,
+                Make = make,
+                Model = model,
+                Year = year,
+                Price = price,
+                Mileage = mileage,
+                City = "Hamilton",
+                Province = "ON",
+                Country = "CA",
+                Currency = "CAD",
+                Condition = Condition.Used,
+                SellerType = SellerType.Dealer,
+                SellerName = "Wayne's Auto World"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error parsing listing element");
+            return null;
+        }
+    }
+
+    protected override async Task<bool> HasNextPageAsync(IPage page, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var nextButton = await page.QuerySelectorAsync(".pagination .next:not(.disabled), a[rel='next']");
+            return nextButton != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking for next page");
+            return false;
+        }
+    }
+
+    protected override string ExtractExternalId(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var match = Regex.Match(url, @"/(?:vehicle|inventory)/([^/\?]+)");
+            if (match.Success)
+            {
+                return match.Groups[1].Value;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return base.ExtractExternalId(url);
+    }
+}


### PR DESCRIPTION
Added 33 new scrapers for new and used car dealerships across Southern Ontario:

Toronto (3):
- Autorama, Nexcar, Car Connection Toronto

Mississauga (3):
- Auto District, Danny & Sons, Mississauga Auto Group

Brampton (3):
- AutoPark Brampton, First Motors, DRIFT Motors

Hamilton (3):
- Global Automart, Wayne's Auto World, Atlas Automotive

Kitchener-Waterloo (3):
- Most Wanted Cars, Quality Car Sales, Fitzgerald Motors

London (3):
- Empire Auto Group, Fine Motors, Cedar Auto

Barrie (3):
- Car Central, G.D. Coates Superstore, AutoPark Barrie

Oshawa/Durham (3):
- AutoPlanet Durham, Boss Auto Sales, True North Automobiles

St. Catharines/Niagara (3):
- CMH Auto Superstore, Skyway Fine Cars, Two Guys Quality Cars

Guelph (2):
- Mark Wilson's, Milburn's Auto Sales

Cambridge (2):
- Lebada Motors, Ontario Auto Outlet

Peterborough (2):
- Auto Connect Sales, John Dewar's Autosource

Burlington/Oakville (2):
- Car Nation Canada Direct, Knight's Auto Sales

Richmond Hill/Markham/Vaughan (1):
- Pfaff Automotive Partners

Updated ScraperFactory to register all new scrapers.